### PR TITLE
Change name to TankWheels

### DIFF
--- a/TankWheels.java
+++ b/TankWheels.java
@@ -35,9 +35,9 @@ import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.util.ElapsedTime;
 import com.qualcomm.robotcore.util.Range;
 
-@TeleOp(name="TankDrive", group="Linear Opmode")
+@TeleOp(name="TankWheels", group="Linear Opmode")
 //@Disabled
-public class TankDriveUpdated extends LinearOpMode {
+public class TankWheels extends LinearOpMode {
 
     // Declare OpMode members.
     private ElapsedTime runtime = new ElapsedTime();


### PR DESCRIPTION
I changed the name of TankDrive to TankWheels because TankWheels fits the purpose of the code better. Those are the only changes made. It looks like I deleted the entire file, but that's because I renamed the file.